### PR TITLE
fix: workaround for foreach terraform issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.48.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt

--- a/aws-iam/group/main.tf
+++ b/aws-iam/group/main.tf
@@ -19,9 +19,9 @@ resource "aws_iam_group" "group" {
 }
 
 resource "aws_iam_group_policy_attachment" "policy_attachments" {
-  for_each   = toset(var.group.policies)
+  count      = length(var.group.policies)
   group      = aws_iam_group.group.name
-  policy_arn = each.value
+  policy_arn = var.group.policies[count.index]
 
   depends_on = [
     aws_iam_group.group,

--- a/aws-iam/policy/main.tf
+++ b/aws-iam/policy/main.tf
@@ -27,11 +27,4 @@ resource "aws_iam_policy" "policy" {
   }, var.policy.tags)
 }
 
-# we compose arn here as role is created where we have access wether this is from 
-# assume role or the user actually accessing.
-locals {
-  arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy${var.policy.path != null ? "${var.policy.path}" : "/"}${var.policy.name}"
-}
-
-
 data "aws_caller_identity" "current" {}

--- a/aws-iam/policy/output.tf
+++ b/aws-iam/policy/output.tf
@@ -3,5 +3,5 @@ output "policy" {
 }
 
 output "policy_arn" {
-  value = local.arn
+  value = aws_iam_policy.policy.arn
 }

--- a/aws-iam/role/main.tf
+++ b/aws-iam/role/main.tf
@@ -25,19 +25,13 @@ resource "aws_iam_role" "role" {
   }, var.role.tags)
 }
 
-resource "aws_iam_role_policy_attachment" "test-attach" {
-  for_each   = toset(var.role.policies)
+resource "aws_iam_role_policy_attachment" "policy_attachment" {
+  count      = length(var.role.policies)
   role       = aws_iam_role.role.name
-  policy_arn = each.value
+  policy_arn = var.role.policies[count.index]
   depends_on = [
     aws_iam_role.role,
   ]
-}
-
-# we compose arn here as role is created where we have access wether this is from 
-# assume role or the user actually accessing.
-locals {
-  arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.role.path != null ? "${var.role.path}" : "/"}${var.role.name}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/aws-iam/role/output.tf
+++ b/aws-iam/role/output.tf
@@ -3,5 +3,5 @@ output "role" {
 }
 
 output "role_arn" {
-  value = local.arn
+  value = aws_iam_role.role.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ module "test-policy" {
   source = "./aws-iam/policy"
 
   policy = {
-    name        = "test-policy"
+    name        = "test-policy-${random_string.test_run_id.result}"
     description = "test policy"
     path        = "/"
     tags        = {}
@@ -53,7 +53,7 @@ module "test-group" {
   source = "./aws-iam/group"
 
   group = {
-    name     = "test-group"
+    name     = "test-group-${random_string.test_run_id.result}"
     path     = "/"
     policies = [module.test-policy.policy_arn]
   }
@@ -63,7 +63,7 @@ module "test-user" {
   source = "./aws-iam/user"
 
   user = {
-    name   = "test-user"
+    name   = "test-user-${random_string.test_run_id.result}"
     path   = "/"
     groups = [module.test-group.group.name]
     tags = {
@@ -110,7 +110,7 @@ module "test-policy2" {
   source = "./aws-iam/policy"
 
   policy = {
-    name        = "test-policy2"
+    name        = "test-policy2-${random_string.test_run_id.result}"
     description = "test policy2"
     path        = "/"
     tags        = {}
@@ -123,7 +123,7 @@ module "test-group2" {
   source = "./aws-iam/group"
 
   group = {
-    name     = "test-group2"
+    name     = "test-group2-${random_string.test_run_id.result}"
     path     = "/test2/"
     policies = [module.test-policy2.policy_arn]
   }
@@ -141,7 +141,7 @@ module "test-user2" {
   source = "./aws-iam/user"
 
   user = {
-    name   = "test-user2"
+    name   = "test-user2-${random_string.test_run_id.result}"
     path   = "/test2/"
     groups = [module.test-group2.group.name]
     tags = {
@@ -154,7 +154,7 @@ module "dummy_role" {
   source = "./aws-iam/role"
 
   role = {
-    name        = "dummy-role"
+    name        = "dummy-role-${random_string.test_run_id.result}"
     description = "dummy role"
     path        = "/"
 
@@ -180,7 +180,7 @@ module "test-role2" {
   source = "./aws-iam/role"
 
   role = {
-    name        = "test-role2"
+    name        = "test-role2-${random_string.test_run_id.result}"
     description = "test role2"
     path        = "/"
 
@@ -193,3 +193,9 @@ module "test-role2" {
   }
 }
 
+resource "random_string" "test_run_id" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Terraform has a very well known issue when using `for_each` based on list + `toset`, whose values depend on an input variable. Story long short: It will complain indefinitely that it cannot know how many elements are in the collection, even if it is obvious. The underlying problem is that it cannot know the value of the map keys.
* The simplest yet robust workaround for this proved to be to use `count` instead of `foreach`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-iam/10)
<!-- Reviewable:end -->
