### PR TITLE
fix: refactor, flatten variables in modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+    rev: v1.84.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -20,6 +20,6 @@ repos:
       - id: terraform_checkov
         exclude: test/
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.15.0
+    rev: v8.18.1
     hooks:
       - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ See inside each submodule for details on the module
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.2.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ See inside each submodule for details on the module
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ See inside each submodule for details on the module
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -137,8 +137,8 @@ module "test-user2" {
 module "dummy_role" {
   source = "./modules/role"
 
-  name        = "dummy-role-${random_string.test_run_id.result}"
-  path        = "/"
+  name = "dummy-role-${random_string.test_run_id.result}"
+  path = "/"
 
   assume_role_policy = <<EOT
 {
@@ -160,8 +160,8 @@ module "dummy_role" {
 module "test-role2" {
   source = "./modules/role"
 
-  name        = "test-role2-${random_string.test_run_id.result}"
-  path        = "/"
+  name = "test-role2-${random_string.test_run_id.result}"
+  path = "/"
 
   assume_role_policy = data.aws_iam_policy_document.assume_role_dummy.json
 

--- a/main.tf
+++ b/main.tf
@@ -34,37 +34,31 @@ data "aws_iam_policy_document" "example" {
 module "test-policy" {
   source = "./modules/policy"
 
-  policy = {
-    name        = "test-policy-${random_string.test_run_id.result}"
-    description = "test policy"
-    path        = "/"
-    tags        = {}
+  name        = "test-policy-${random_string.test_run_id.result}"
+  description = "test policy"
+  path        = "/"
+  tags        = {}
 
-    policy = data.aws_iam_policy_document.example.json
-  }
+  policy = data.aws_iam_policy_document.example.json
 }
 
 #tfsec:ignore:aws-iam-enforce-mfa # Dummy policy used for demoing module
 module "test-group" {
   source = "./modules/group"
 
-  group = {
-    name     = "test-group-${random_string.test_run_id.result}"
-    path     = "/"
-    policies = [module.test-policy.policy_arn]
-  }
+  name     = "test-group-${random_string.test_run_id.result}"
+  path     = "/"
+  policies = [module.test-policy.policy_arn]
 }
 
 module "test-user" {
   source = "./modules/user"
 
-  user = {
-    name   = "test-user-${random_string.test_run_id.result}"
-    path   = "/"
-    groups = [module.test-group.group.name]
-    tags = {
+  name   = "test-user-${random_string.test_run_id.result}"
+  path   = "/"
+  groups = [module.test-group.group.name]
+  tags = {
 
-    }
   }
 }
 
@@ -105,26 +99,21 @@ data "aws_iam_policy_document" "allow_assume_dummy_role" {
 module "test-policy2" {
   source = "./modules/policy"
 
-  policy = {
-    name        = "test-policy2-${random_string.test_run_id.result}"
-    description = "test policy2"
-    path        = "/"
-    tags        = {}
+  name        = "test-policy2-${random_string.test_run_id.result}"
+  description = "test policy2"
+  path        = "/"
+  tags        = {}
 
-    policy = data.aws_iam_policy_document.allow_assume_dummy_role.json
-  }
+  policy = data.aws_iam_policy_document.allow_assume_dummy_role.json
 }
 
 #tfsec:ignore:aws-iam-enforce-mfa # Dummy policy used for demoing module
 module "test-group2" {
   source = "./modules/group"
 
-  group = {
-    name     = "test-group2-${random_string.test_run_id.result}"
-    path     = "/test2/"
-    policies = [module.test-policy2.policy_arn]
-  }
-
+  name     = "test-group2-${random_string.test_run_id.result}"
+  path     = "/test2/"
+  policies = [module.test-policy2.policy_arn]
 }
 
 data "aws_iam_policy" "test_policy2_arn" {
@@ -137,25 +126,21 @@ data "aws_iam_policy" "test_policy2_arn" {
 module "test-user2" {
   source = "./modules/user"
 
-  user = {
-    name   = "test-user2-${random_string.test_run_id.result}"
-    path   = "/test2/"
-    groups = [module.test-group2.group.name]
-    tags = {
+  name   = "test-user2-${random_string.test_run_id.result}"
+  path   = "/test2/"
+  groups = [module.test-group2.group.name]
+  tags = {
 
-    }
   }
 }
 
 module "dummy_role" {
   source = "./modules/role"
 
-  role = {
-    name        = "dummy-role-${random_string.test_run_id.result}"
-    description = "dummy role"
-    path        = "/"
+  name        = "dummy-role-${random_string.test_run_id.result}"
+  path        = "/"
 
-    assume_role_policy = <<EOT
+  assume_role_policy = <<EOT
 {
   "Version": "2012-10-17",
   "Statement": {
@@ -164,30 +149,26 @@ module "dummy_role" {
     "Action": "sts:AssumeRole"
   }
 }
-    EOT
+  EOT
 
-    tags = {
+  tags = {
 
-    }
-    policies = []
   }
+  policies = []
 }
 
 module "test-role2" {
   source = "./modules/role"
 
-  role = {
-    name        = "test-role2-${random_string.test_run_id.result}"
-    description = "test role2"
-    path        = "/"
+  name        = "test-role2-${random_string.test_run_id.result}"
+  path        = "/"
 
-    assume_role_policy = data.aws_iam_policy_document.assume_role_dummy.json
+  assume_role_policy = data.aws_iam_policy_document.assume_role_dummy.json
 
-    tags = {
+  tags = {
 
-    }
-    policies = [module.test-policy2.policy_arn]
   }
+  policies = [module.test-policy2.policy_arn]
 }
 
 resource "random_string" "test_run_id" {

--- a/modules/group/README.md
+++ b/modules/group/README.md
@@ -30,7 +30,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | The name of the user | `string` | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | The path of the user | `string` | `null` | no |
-| <a name="input_policies"></a> [policies](#input\_policies) | The tags of the user | `list(string)` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | The policies of the user | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/modules/group/README.md
+++ b/modules/group/README.md
@@ -28,7 +28,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_group"></a> [group](#input\_group) | Name and path of group | <pre>object({<br>    name     = string<br>    path     = string<br>    policies = list(string) # policy arns<br>  })</pre> | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the user | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | The path of the user | `string` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | The tags of the user | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/modules/group/README.md
+++ b/modules/group/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
 
 ## Modules
 

--- a/modules/group/main.tf
+++ b/modules/group/main.tf
@@ -10,14 +10,14 @@ terraform {
 }
 
 resource "aws_iam_group" "group" {
-  name = var.group.name
-  path = var.group.path
+  name = var.name
+  path = var.path
 }
 
 resource "aws_iam_group_policy_attachment" "policy_attachments" {
-  count      = length(var.group.policies)
+  count      = length(var.policies)
   group      = aws_iam_group.group.name
-  policy_arn = var.group.policies[count.index]
+  policy_arn = var.policies[count.index]
 
   depends_on = [
     aws_iam_group.group,

--- a/modules/group/variables.tf
+++ b/modules/group/variables.tf
@@ -1,9 +1,17 @@
-variable "group" {
-  description = "Name and path of group"
-  type = object({
-    name     = string
-    path     = string
-    policies = list(string) # policy arns
-  })
-  nullable = false
+variable "name" {
+  description = "The name of the user"
+  type = string
+  default = null
+}
+
+variable "path" {
+  description = "The path of the user"
+  type = string
+  default = null
+}
+
+variable "policies" {
+  description = "The tags of the user"
+  type = list(string)
+  default = null
 }

--- a/modules/group/variables.tf
+++ b/modules/group/variables.tf
@@ -1,17 +1,17 @@
 variable "name" {
   description = "The name of the user"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "path" {
   description = "The path of the user"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "policies" {
-  description = "The tags of the user"
-  type = list(string)
-  default = null
+  description = "The policies of the user"
+  type        = list(string)
+  default     = null
 }

--- a/modules/policy/README.md
+++ b/modules/policy/README.md
@@ -27,7 +27,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_policy"></a> [policy](#input\_policy) | Policy | <pre>object({<br>    name        = string<br>    path        = string<br>    description = string<br>    policy      = string<br>    tags        = map(any)<br>  })</pre> | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | The description of the policy | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the policy | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | The path of the policy | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | The policy of the policy | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | The tags of the policy | `map(any)` | `null` | no |
 
 ## Outputs
 

--- a/modules/policy/README.md
+++ b/modules/policy/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
 
 ## Modules
 

--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -10,17 +10,17 @@ terraform {
 }
 
 resource "aws_iam_policy" "policy" {
-  name        = var.policy.name
-  path        = var.policy.path
-  description = var.policy.description
+  name        = var.name
+  path        = var.path
+  description = var.description
 
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.
-  policy = var.policy.policy
+  policy = var.policy
 
   tags = merge({
     createdBy = "terraform aws-iam/policy"
-  }, var.policy.tags)
+  }, var.tags)
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/policy/variables.tf
+++ b/modules/policy/variables.tf
@@ -1,11 +1,29 @@
+variable "name" {
+  description = "The name of the policy"
+  type = string
+  default = null
+}
+
+variable "path" {
+  description = "The path of the policy"
+  type = string
+  default = null
+}
+
+variable "description" {
+  description = "The description of the policy"
+  type = string
+  default = null
+}
+
 variable "policy" {
-  description = "Policy"
-  type = object({
-    name        = string
-    path        = string
-    description = string
-    policy      = string
-    tags        = map(any)
-  })
-  nullable = false
+  description = "The policy of the policy"
+  type = string
+  default = null
+}
+
+variable "tags" {
+  description = "The tags of the policy"
+  type = map(any)
+  default = null
 }

--- a/modules/policy/variables.tf
+++ b/modules/policy/variables.tf
@@ -1,29 +1,29 @@
 variable "name" {
   description = "The name of the policy"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "path" {
   description = "The path of the policy"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "description" {
   description = "The description of the policy"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "policy" {
   description = "The policy of the policy"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "tags" {
   description = "The tags of the policy"
-  type = map(any)
-  default = null
+  type        = map(any)
+  default     = null
 }

--- a/modules/role/README.md
+++ b/modules/role/README.md
@@ -28,7 +28,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_role"></a> [role](#input\_role) | The role to create | <pre>object({<br>    name               = string<br>    path               = string<br>    tags               = map(any)<br>    assume_role_policy = string<br>    policies           = list(string) # policy arn<br>  })</pre> | n/a | yes |
+| <a name="input_assume_role_policy"></a> [assume\_role\_policy](#input\_assume\_role\_policy) | The assume role policy of the role | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the role | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | The path of the role | `string` | `null` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | The policies of the role | `list(string)` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | The tags of the role | `map(any)` | `null` | no |
 
 ## Outputs
 

--- a/modules/role/README.md
+++ b/modules/role/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
 
 ## Modules
 

--- a/modules/role/main.tf
+++ b/modules/role/main.tf
@@ -10,21 +10,21 @@ terraform {
 }
 
 resource "aws_iam_role" "role" {
-  name = var.role.name
-  path = var.role.path
+  name = var.name
+  path = var.path
 
   force_detach_policies = true
 
-  assume_role_policy = var.role.assume_role_policy
+  assume_role_policy = var.assume_role_policy
   tags = merge({
     createdBy = "terraform aws-iam/role"
-  }, var.role.tags)
+  }, var.tags)
 }
 
 resource "aws_iam_role_policy_attachment" "policy_attachment" {
-  count      = length(var.role.policies)
+  count      = length(var.policies)
   role       = aws_iam_role.role.name
-  policy_arn = var.role.policies[count.index]
+  policy_arn = var.policies[count.index]
   depends_on = [
     aws_iam_role.role,
   ]

--- a/modules/role/variables.tf
+++ b/modules/role/variables.tf
@@ -1,29 +1,29 @@
 variable "name" {
   description = "The name of the role"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "path" {
   description = "The path of the role"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "tags" {
   description = "The tags of the role"
-  type = map(any)
-  default = null
+  type        = map(any)
+  default     = null
 }
 
 variable "assume_role_policy" {
   description = "The assume role policy of the role"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "policies" {
   description = "The policies of the role"
-  type = list(string) # policy arn
-  default = null
+  type        = list(string) # policy arn
+  default     = null
 }

--- a/modules/role/variables.tf
+++ b/modules/role/variables.tf
@@ -1,11 +1,29 @@
-variable "role" {
-  description = "The role to create"
-  type = object({
-    name               = string
-    path               = string
-    tags               = map(any)
-    assume_role_policy = string
-    policies           = list(string) # policy arn
-  })
-  nullable = false
+variable "name" {
+  description = "The name of the role"
+  type = string
+  default = null
+}
+
+variable "path" {
+  description = "The path of the role"
+  type = string
+  default = null
+}
+
+variable "tags" {
+  description = "The tags of the role"
+  type = map(any)
+  default = null
+}
+
+variable "assume_role_policy" {
+  description = "The assume role policy of the role"
+  type = string
+  default = null
+}
+
+variable "policies" {
+  description = "The policies of the role"
+  type = list(string) # policy arn
+  default = null
 }

--- a/modules/user/README.md
+++ b/modules/user/README.md
@@ -27,7 +27,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_user"></a> [user](#input\_user) | The user to create | <pre>object({<br>    name   = string<br>    path   = string<br>    tags   = map(any)<br>    groups = list(string) # group names<br>  })</pre> | n/a | yes |
+| <a name="input_groups"></a> [groups](#input\_groups) | The groups of the user | `list(string)` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the user | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | The path of the user | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | The tags of the user | `map(any)` | `null` | no |
 
 ## Outputs
 

--- a/modules/user/README.md
+++ b/modules/user/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
 
 ## Modules
 

--- a/modules/user/main.tf
+++ b/modules/user/main.tf
@@ -11,19 +11,19 @@ terraform {
 
 resource "aws_iam_user" "user" {
   #checkov:skip=CKV_AWS_273:Will move to SSO in the future
-  name = var.user.name
-  path = var.user.path
+  name = var.name
+  path = var.path
 
   force_destroy = true
 
   tags = merge(
     { createdBy = "createdBy aws-iam/user" },
-    var.user.tags
+    var.tags
   )
 }
 
 resource "aws_iam_user_group_membership" "groups_attached" {
   user = aws_iam_user.user.name
 
-  groups = var.user.groups
+  groups = var.groups
 }

--- a/modules/user/variables.tf
+++ b/modules/user/variables.tf
@@ -1,10 +1,23 @@
-variable "user" {
-  description = "The user to create"
-  type = object({
-    name   = string
-    path   = string
-    tags   = map(any)
-    groups = list(string) # group names
-  })
-  nullable = false
+variable "name" {
+  description = "The name of the user"
+  type = string
+  default = null
+}
+
+variable "path" {
+  description = "The path of the user"
+  type = string
+  default = null
+}
+
+variable "tags" {
+  description = "The tags of the user"
+  type = map(any)
+  default = null
+}
+
+variable "groups" {
+  description = "The groups of the user"
+  type = list(string)
+  default = null
 }

--- a/modules/user/variables.tf
+++ b/modules/user/variables.tf
@@ -1,23 +1,23 @@
 variable "name" {
   description = "The name of the user"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "path" {
   description = "The path of the user"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "tags" {
   description = "The tags of the user"
-  type = map(any)
-  default = null
+  type        = map(any)
+  default     = null
 }
 
 variable "groups" {
   description = "The groups of the user"
-  type = list(string)
-  default = null
+  type        = list(string)
+  default     = null
 }


### PR DESCRIPTION
BREAKING CHANGE: flatten variables for modules

<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Flatten variables:

modules are called now as 

```terraform
module "test-role2" {
  source = "./modules/role"

  name        = "test-role2-${random_string.test_run_id.result}"
  description = "test role2"
  path        = "/"

  assume_role_policy = data.aws_iam_policy_document.assume_role_dummy.json

  tags = {

  }
  policies = [module.test-policy2.policy_arn]
}
```

instead of :

```terraform
module "test-role2" {
  source = "./modules/role"

  role = {
    name        = "test-role2-${random_string.test_run_id.result}"
    description = "test role2"
    path        = "/"

    assume_role_policy = data.aws_iam_policy_document.assume_role_dummy.json

    tags = {

    }
    policies = [module.test-policy2.policy_arn]
  }
}
```

ps: I wanted to use this and got annoyed with the nested variables
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-iam/19)
<!-- Reviewable:end -->
