### PR TITLE
fix: pin trivy-action to safe version (security incident response)

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -24,7 +24,7 @@ jobs:
 
       # Run Trivy Configuration Scan with specified options.
       - name: Run Trivy Security Scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'config'
           trivy-config: 'trivy.yaml'


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] I have confirmed that the PR type is appropriate for the change I am making.
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Pin `aquasecurity/trivy-action` to safe version `v0.35.0` (SHA: `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`) per the security advisory: https://github.com/aquasecurity/trivy/discussions/10425
* Ref: SEC-505